### PR TITLE
css で require_tree をやめて個別に scss を読むようにした

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,5 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
  *= require_self
  */

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,10 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+
+    -# ページ固有の CSS を読み込む
+    = stylesheet_link_tag controller_name, media: 'all', 'data-turbolinks-track': 'reload'
+
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = yield


### PR DESCRIPTION
require_tree は後からメンテできなくなるので早めに外しておく。
また、ページ毎に CSS を用意する方が、不要な CSS を読まなくていいので個別で読めるようにしている