### PR TITLE
場所と訪問評価を同時に登録できるようにした

### DIFF
--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -15,6 +15,7 @@ class StocksController < ApplicationController
   # GET /stocks/new
   def new
     @place = Place.new
+    @place_evaluation = @place.evaluations.build
   end
 
   # GET /stocks/1/edit
@@ -25,7 +26,7 @@ class StocksController < ApplicationController
   # POST /stocks.json
   def create
     @place = Place.new(place_params)
-    @place.evaluations.build(place_evaluation_params)
+    @place_evaluation = @place.evaluations.build(place_evaluation_params)
 
     respond_to do |format|
       if @place.save

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -70,10 +70,10 @@ class StocksController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def place_params
-      params.require(:place).permit(:name, :address)
+      params.fetch(:stock, {}).require(:place).permit(:name, :address)
     end
 
     def place_evaluation_params
-      params.require(:place_evaluation).permit(:visited_on, :point)
+      params.fetch(:stock, {}).require(:place_evaluation).permit(:visited_on, :point)
     end
 end

--- a/app/controllers/stocks_controller.rb
+++ b/app/controllers/stocks_controller.rb
@@ -18,10 +18,6 @@ class StocksController < ApplicationController
     @place_evaluation = @place.evaluations.build
   end
 
-  # GET /stocks/1/edit
-  def edit
-  end
-
   # POST /stocks
   # POST /stocks.json
   def create
@@ -34,20 +30,6 @@ class StocksController < ApplicationController
         format.json { render :show, status: :created, location: stock_path(@place.id) }
       else
         format.html { render :new }
-        format.json { render json: @place.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /stocks/1
-  # PATCH/PUT /stocks/1.json
-  def update
-    respond_to do |format|
-      if @place.update(place_params)
-        format.html { redirect_to stock_path(@place), notice: 'Place was successfully updated.' }
-        format.json { render :show, status: :ok, location: stock_path(@place.id) }
-      else
-        format.html { render :edit }
         format.json { render json: @place.errors, status: :unprocessable_entity }
       end
     end

--- a/app/views/stocks/_form.html.haml
+++ b/app/views/stocks/_form.html.haml
@@ -1,26 +1,28 @@
-= form_with model: @place, url: @place.new_record? ? stocks_path : stock_path(@place) do |f|
+= form_with scope: :stock, url: @place.new_record? ? stocks_path : stock_path(@place) do |f|
   - if @place.errors.any?
     #error_explanation
       %h2= "#{pluralize(@place.errors.count, "error")} prohibited this stock from being saved:"
       %ul
         - @place.errors.full_messages.each do |msg|
           %li= msg
-  = f.label :name do
-    名称
-    = f.text_field :name
-  = f.label :address do
-    住所
-    = f.text_field :address
+  = f.fields_for :place, @place do |place_f|
+    = place_f.label :name do
+      名称
+      = place_f.text_field :name
+    = place_f.label :address do
+      住所
+      = place_f.text_field :address
 
-  = f.label :visited_on do
-    訪問日
-    = f.date_field :visited_on
-  %fieldset
-    %legend リピートあり?
-    - PlaceEvaluation.point.values.each do |value|
-      = label_tag do
-        = f.radio_button(:point, value)
-        = t("enumerize.place_evaluation.point.#{value}")
+  = f.fields_for :place_evaluation, @place_evaluation do |evaluation_f|
+    = evaluation_f.label :visited_on do
+      訪問日
+      = evaluation_f.date_field :visited_on
+    %fieldset
+      %legend リピートあり?
+      - PlaceEvaluation.point.values.each do |value|
+        = label_tag do
+          = evaluation_f.radio_button(:point, value)
+          = t("enumerize.place_evaluation.point.#{value}")
 
   .actions
     = f.submit 'Save'

--- a/app/views/stocks/_form.html.haml
+++ b/app/views/stocks/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with scope: :stock, url: @place.new_record? ? stocks_path : stock_path(@place) do |f|
+= form_with scope: :stock, url: @place.new_record? ? stocks_path : stock_path(@place), local: true do |f|
   - if @place.errors.any?
     #error_explanation
       %h2= "#{pluralize(@place.errors.count, "error")} prohibited this stock from being saved:"

--- a/app/views/stocks/_form.html.haml
+++ b/app/views/stocks/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with scope: :stock, url: @place.new_record? ? stocks_path : stock_path(@place), local: true do |f|
+= form_with scope: :stock, url: stocks_path, local: true do |f|
   - if @place.errors.any?
     #error_explanation
       %h2= "#{pluralize(@place.errors.count, "error")} prohibited this stock from being saved:"

--- a/app/views/stocks/_form.html.haml
+++ b/app/views/stocks/_form.html.haml
@@ -12,5 +12,15 @@
     住所
     = f.text_field :address
 
+  = f.label :visited_on do
+    訪問日
+    = f.date_field :visited_on
+  %fieldset
+    %legend リピートあり?
+    - PlaceEvaluation.point.values.each do |value|
+      = label_tag do
+        = f.radio_button(:point, value)
+        = t("enumerize.place_evaluation.point.#{value}")
+
   .actions
     = f.submit 'Save'

--- a/app/views/stocks/edit.html.haml
+++ b/app/views/stocks/edit.html.haml
@@ -1,7 +1,0 @@
-%h1 Editing stock
-
-= render 'form'
-
-= link_to 'Show', @stock
-\|
-= link_to 'Back', stocks_path

--- a/app/views/stocks/index.html.haml
+++ b/app/views/stocks/index.html.haml
@@ -13,13 +13,11 @@
       %th 住所
       %th
       %th
-      %th
     - @places.each do |place|
       %tr
         %td= place.name
         %td= place.address
         %td= link_to 'Show', stock_path(place)
-        %td= link_to 'Edit', edit_stock_path(place)
         %td= link_to 'Destroy', stock_path(place), :method => :delete, :data => { :confirm => 'Are you sure?' }
 
 = link_to 'New Stock', new_stock_path

--- a/app/views/stocks/show.html.haml
+++ b/app/views/stocks/show.html.haml
@@ -14,6 +14,4 @@
     %dt リピートあり?
     %dd= evaluation.point_text
 
-= link_to 'Edit', edit_stock_path(@place)
-\|
 = link_to 'Back', stocks_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,7 +17,7 @@ ja:
     - 金
     - 土
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -43,7 +43,7 @@ ja:
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -24,7 +24,7 @@ ja:
   enumerize:
     place_evaluation:
       point:
-        bad: なし
+        no_good: なし
         no_comment: 未訪問/ノーコメント
         not_bad: たまになら
         good: あり

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root 'home#index'
 
-  resources :stocks
+  resources :stocks, only: %i(index new show create destroy)
 end

--- a/spec/requests/stocks_spec.rb
+++ b/spec/requests/stocks_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Stocks', type: :request do
       params = {
         stock: {
           place: place_params.merge(address: 'test 1-1-1'),
-          place_evaluation: place_evaluation_params.merge(visited_on: Date.today, point: :not_bad)
+          place_evaluation: place_evaluation_params.merge(visited_on: Date.yesterday, point: "not_bad")
         }
       }
       post stocks_path, params: params
@@ -26,8 +26,9 @@ RSpec.describe 'Stocks', type: :request do
         follow_redirect!
 
         expect(response).to have_http_status(:success)
+        expect(response.body).not_to include('New stock')
         expect(response.body).to include('test 1-1-1')
-        expect(response.body).to include(Date.today.to_s(:db)) # TODO: I18n
+        expect(response.body).to include(Date.yesterday.to_s(:db)) # TODO: I18n
         expect(response.body).to include('たまになら')
       end
     end

--- a/spec/requests/stocks_spec.rb
+++ b/spec/requests/stocks_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe 'Stocks', type: :request do
   describe 'POST /stocks' do
     it '場所と評価を同時にストックできる' do
       params = {
-        place: place_params.merge(address: 'test 1-1-1'),
-        place_evaluation: place_evaluation_params.merge(visited_on: Date.today, point: :not_bad)
+        stock: {
+          place: place_params.merge(address: 'test 1-1-1'),
+          place_evaluation: place_evaluation_params.merge(visited_on: Date.today, point: :not_bad)
+        }
       }
       post stocks_path, params: params
 

--- a/spec/requests/stocks_spec.rb
+++ b/spec/requests/stocks_spec.rb
@@ -34,26 +34,6 @@ RSpec.describe 'Stocks', type: :request do
     end
   end
 
-  describe 'PUT /stocks/:id' do
-    it 'ストックした場所を更新できる' do
-      create_params = place_params.merge(name: 'おいしいラーメン屋')
-      place = create(:place, create_params)
-
-      params = { place: place_params.merge(name: 'おいしい中華料理屋') }
-      put stock_path(place), params: params
-
-      aggregate_failures do
-        expect(response).to have_http_status(:found)
-
-        follow_redirect!
-
-        expect(response).to have_http_status(:success)
-        expect(response.body).not_to include('ラーメン屋')
-        expect(response.body).to include('中華料理屋')
-      end
-    end
-  end
-
   describe 'DELETE /stocks/:id' do
     it 'ストックした場所を削除できる' do
       create_params = place_params.merge(name: 'おいしいラーメン屋')

--- a/spec/routing/stocks_routing_spec.rb
+++ b/spec/routing/stocks_routing_spec.rb
@@ -14,21 +14,8 @@ RSpec.describe StocksController, type: :routing do
       expect(:get => "/stocks/1").to route_to("stocks#show", :id => "1")
     end
 
-    it "routes to #edit" do
-      expect(:get => "/stocks/1/edit").to route_to("stocks#edit", :id => "1")
-    end
-
-
     it "routes to #create" do
       expect(:post => "/stocks").to route_to("stocks#create")
-    end
-
-    it "routes to #update via PUT" do
-      expect(:put => "/stocks/1").to route_to("stocks#update", :id => "1")
-    end
-
-    it "routes to #update via PATCH" do
-      expect(:patch => "/stocks/1").to route_to("stocks#update", :id => "1")
     end
 
     it "routes to #destroy" do

--- a/spec/system/stocks_spec.rb
+++ b/spec/system/stocks_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe "Stocks", type: :system do
+RSpec.describe 'Stocks', type: :system do
   before do
     driven_by(:rack_test)
   end
 
-  describe "新しいストック" do
-    context "入力が正しければ" do
-      it "Stock を投稿できる" do
+  describe '新しいストック' do
+    context '入力が正しければ' do
+      it 'Stock を投稿できる' do
         visit '/'
 
         click_on 'Stock!'
@@ -23,6 +23,27 @@ RSpec.describe "Stocks", type: :system do
         expect(page).to have_text('successfully') # TODO: I18n
         expect(page).to have_text('Stock')
         expect(page).to have_text('M78星雲')
+      end
+    end
+
+    context '入力が間違えていれば' do
+      it 'Stock の投稿に失敗し投稿フォームが再表示される' do
+        visit '/'
+
+        click_on 'Stock!'
+
+        fill_in '名称', with: ''
+        fill_in '住所', with: '宇宙の彼方'
+
+        fill_in '訪問日', with: '2020/01/01'
+        choose 'あり'
+
+        click_on 'Save' # TODO: I18n
+
+        expect(page).not_to have_text('successfully') # TODO: I18n
+        expect(page).to have_text('New stock')
+        expect(page).to have_text('名称を入力してください')
+        expect(page).to have_text('宇宙の彼方')
       end
     end
   end

--- a/spec/system/stocks_spec.rb
+++ b/spec/system/stocks_spec.rb
@@ -5,5 +5,21 @@ RSpec.describe "Stocks", type: :system do
     driven_by(:rack_test)
   end
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+  it "Stock を投稿できる" do
+    visit '/'
+
+    click_on 'Stock!'
+
+    fill_in '名称', with: 'M78星雲'
+    fill_in '住所', with: '宇宙の彼方'
+
+    fill_in '訪問日', with: '2020/01/01'
+    choose 'あり'
+
+    click_on 'Save' # TODO: I18n
+
+    expect(page).to have_text('Successfly') # TODO: I18n
+    expect(page).to have_text('Stock')
+    expect(page).to have_text('M78星雲')
+  end
 end

--- a/spec/system/stocks_spec.rb
+++ b/spec/system/stocks_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Stocks', type: :system do
         expect(page).not_to have_text('successfully') # TODO: I18n
         expect(page).to have_text('New stock')
         expect(page).to have_text('名称を入力してください')
-        expect(page).to have_text('宇宙の彼方')
+        expect(page).to have_field('住所', with: '宇宙の彼方')
       end
     end
   end

--- a/spec/system/stocks_spec.rb
+++ b/spec/system/stocks_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "Stocks", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/stocks_spec.rb
+++ b/spec/system/stocks_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Stocks", type: :system do
 
     click_on 'Save' # TODO: I18n
 
-    expect(page).to have_text('Successfly') # TODO: I18n
+    expect(page).to have_text('successfully') # TODO: I18n
     expect(page).to have_text('Stock')
     expect(page).to have_text('M78星雲')
   end

--- a/spec/system/stocks_spec.rb
+++ b/spec/system/stocks_spec.rb
@@ -5,21 +5,25 @@ RSpec.describe "Stocks", type: :system do
     driven_by(:rack_test)
   end
 
-  it "Stock を投稿できる" do
-    visit '/'
+  describe "新しいストック" do
+    context "入力が正しければ" do
+      it "Stock を投稿できる" do
+        visit '/'
 
-    click_on 'Stock!'
+        click_on 'Stock!'
 
-    fill_in '名称', with: 'M78星雲'
-    fill_in '住所', with: '宇宙の彼方'
+        fill_in '名称', with: 'M78星雲'
+        fill_in '住所', with: '宇宙の彼方'
 
-    fill_in '訪問日', with: '2020/01/01'
-    choose 'あり'
+        fill_in '訪問日', with: '2020/01/01'
+        choose 'あり'
 
-    click_on 'Save' # TODO: I18n
+        click_on 'Save' # TODO: I18n
 
-    expect(page).to have_text('successfully') # TODO: I18n
-    expect(page).to have_text('Stock')
-    expect(page).to have_text('M78星雲')
+        expect(page).to have_text('successfully') # TODO: I18n
+        expect(page).to have_text('Stock')
+        expect(page).to have_text('M78星雲')
+      end
+    end
   end
 end


### PR DESCRIPTION
訪問した情報をまとめて投稿できるようにしました

それに伴って、元々編集できていたのをできないようにしました。
場所の情報と評価情報の修正は別扱いにしたい