### PR TITLE
正しくカバレッジを取るために simplecov の起動設定を修正した

### DIFF
--- a/spec/support/simplecov.rb
+++ b/spec/support/simplecov.rb
@@ -6,4 +6,4 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   Coveralls::SimpleCov::Formatter
 ])
 
-SimpleCov.start
+SimpleCov.start 'rails'


### PR DESCRIPTION
```
SimpleCov.start 'rails'
```

と記述すると app,libs を全部読み込んでくれるようになるのでその設定を導入